### PR TITLE
Eduardo/1 adding terraform extensions to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -426,7 +426,8 @@ override.tf.json
 *_override.tf.json
 
 # Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
+# Ignore Terraform lock file
+.terraform.lock.hcl
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*


### PR DESCRIPTION
This pull request introduces terraform extensions to the current gitignore file.

Key changes include:
Terraform file extensions to the gitignore file, like:

- Local .terraform directories
- Crash log files
- Exclude all .tfvars files, which are likely to contain sensitive data, such as password, private keys, and other secrets. These should not be part of version control as they are data points which are potentially sensitive and subject to change depending on the environment.
- Ignore override files as they are usually used to override resources locally and so are not checked in
- Include override files you do wish to add to version control using negated pattern
- Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
- Ignore CLI configuration files
- Plan files, review if this will be required

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
//Create a new tfvars file and try to merged  it to main.

touch new.tfvars
git merge new.tfvars

```

## What to Check
Verify that the following are valid
We can't merge:
*  tfvars files that store values and secrets.
*  local terraform directories
*  crash log files
*  override files
*  tfplan files
*  CLI configuration files

