### PR TITLE
fix: move partner_id for telemetry to provider config and add appropriate disclosure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,6 @@
         // Forward ports if needed for local development
     ],
     "containerEnv": {
-        "ARM_PARTNER_ID": "acce1e78-90a1-4306-89d1-a03ed6284007",
         "POWER_PLATFORM_USE_CLI": "true"
     },
     "postCreateCommand": "pip install --upgrade pip && pip install checkov",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Project Name
+# Copilot Studio with Azure AI Search
 
 This repository provides a baseline architecture for integrating Copilot Studio and Power Platform with Azure AI resources. It addresses challenges in initializing and managing these connections while prioritizing enterprise readiness. Key features include robust network configuration, observability tools, and secure, scalable authentication.
 
@@ -58,3 +58,9 @@ To run the demo, follow these steps:
 - Link to supporting information
 - Link to similar sample
 - ...
+
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described below. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at https://go.microsoft.com/fwlink/?LinkID=824704. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+
+The `partner_id` configuration in [infra/providers.tf](./infra/provider.tf) enables anonymous telemetry that helps us justify ongoing investment in maintaining and improving this template.  Keeping this enabled supports the project and future feature development. To opt out of this telemetry, simply remove `partner_id`. When enabled, the `partner_id` is appended to the `User-Agent` on requests made by the configured terraform providers.

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -47,6 +47,16 @@ provider "azurerm" {
       prevent_deletion_if_contains_resources = false
     }
   }
+
+  # partner_id enables anonymous telemetry that helps us justify ongoing investment in maintaining and improving this template.
+  # Keeping this line supports the project and future feature development. To opt out of telemetry, simply remove the line below.
+  partner_id = "acce1e78-90a1-4306-89d1-a03ed6284007"
+}
+
+provider "azapi" {
+  # partner_id enables anonymous telemetry that helps us justify ongoing investment in maintaining and improving this template.
+  # Keeping this line supports the project and future feature development. To opt out of telemetry, simply remove the line below.
+  partner_id = "acce1e78-90a1-4306-89d1-a03ed6284007"
 }
 
 # Access client_id, tenant_id, subscription_id and object_id configuration values


### PR DESCRIPTION

## Description

This pull request introduces updates to improve documentation, enhance transparency around data collection, and adjust telemetry configurations. The most important changes include renaming the project in the `README.md`, adding a detailed data collection notice, and centralizing telemetry configuration by moving the `partner_id` from the development container to Terraform provider files.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Renamed the project to "Copilot Studio with Azure AI Search" and added a new "Data Collection" section explaining telemetry practices, including how to opt out and the purpose of the `partner_id` configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R66)

### Telemetry Configuration:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L38): Removed the `ARM_PARTNER_ID` environment variable, centralizing telemetry configuration in Terraform files.
* [`infra/provider.tf`](diffhunk://#diff-41f8c2a70e267281aa1bca58cc75bda58efea111a2e3b547d971441c5c08be10R50-R59): Added `partner_id` to the `azurerm` and `azapi` providers to enable anonymous telemetry, with instructions on how to opt out.

## Related Issue(s)

Resolves #45 
