### PR TITLE
Adds deployment and provisioning hooks for Azd

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ To use this example, you must complete the following prerequisites:
 - The interactive user needs licenses assigned for Microsoft Power Apps, Power Automate, and Copilot Studio in the M365 Admin Center.
 - Ensure that the shell you use to access the example has azd installed, and if not, follow the [instructions to install azd](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd?tabs=winget-windows%2Cbrew-mac%2Cscript-linux&pivots=os-windows).
 - Update the following Power Platform tenant settings to enable Copilot features: Copilot in Power Apps; Publish Copilots with AI features.
+- This template leverages [Azure Developer CLI hooks](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/azd-extensibility) to enhance AZD commands by enabling additional configurations through PowerShell. For non-Windows operating systems, ensure that PowerShell 7 (pwsh) is installed to support these extensions effectively.
 
 ### Quickstart
 
@@ -135,6 +136,7 @@ To run the demo, follow these steps:
 - [Power Platform environment basics](https://learn.microsoft.com/en-us/power-platform/admin/environments-overview)
 - [Copilot Studio getting started](https://learn.microsoft.com/en-us/microsoft-copilot-studio/fundamentals-get-started?tabs=web)
 - [Azure AI Search resources](https://learn.microsoft.com/en-us/azure/search/)
+- [Azure Developer CLI Hooks](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/azd-extensibility)
 
 ## Data Collection
 

--- a/azd-hooks/postdeploy.sh
+++ b/azd-hooks/postdeploy.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Execute Post-Deploy Hook"

--- a/azd-hooks/postpackage.ps1
+++ b/azd-hooks/postpackage.ps1
@@ -1,0 +1,1 @@
+Write-Host "Execute Post-Package Hook"

--- a/azd-hooks/postprovision.sh
+++ b/azd-hooks/postprovision.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Execute Post-Provision Hook"

--- a/azd-hooks/predeploy.sh
+++ b/azd-hooks/predeploy.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Execute Pre-Deploy Hook"

--- a/azd-hooks/prepackage.ps1
+++ b/azd-hooks/prepackage.ps1
@@ -1,0 +1,1 @@
+Write-Host "Execute Pre-Package Hook"

--- a/azd-hooks/preprovision.sh
+++ b/azd-hooks/preprovision.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo "Execute Pre-Provision Hook"

--- a/azure.yaml
+++ b/azure.yaml
@@ -6,46 +6,32 @@ infra:
   provider: terraform
 hooks:
   preprovision:
-    posix:
-      shell: sh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/preprovision.sh
-    windows:
-      shell: pwsh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/preprovision.ps1
+    shell: pwsh
+    continueOnError: false
+    interactive: false
+    run: azd-hooks/preprovision.ps1
   postprovision:
-    posix:
-      shell: sh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/postprovision.sh
-    windows:
-      shell: pwsh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/postprovision.ps1
+    shell: pwsh
+    continueOnError: false
+    interactive: false
+    run: azd-hooks/postprovision.ps1
   predeploy:
-    posix:
-      shell: sh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/predeploy.sh
-    windows:
-      shell: pwsh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/predeploy.ps1
+    shell: pwsh
+    continueOnError: false
+    interactive: false
+    run: azd-hooks/predeploy.ps1
   postdeploy:
-    posix:
-      shell: sh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/postdeploy.sh
-    windows:
-      shell: pwsh
-      continueOnError: false
-      interactive: false
-      run: azd-hooks/postdeploy.ps1
+    shell: pwsh
+    continueOnError: false
+    interactive: false
+    run: azd-hooks/postdeploy.ps1
+  prepackage:
+    shell: pwsh
+    continueOnError: false
+    interactive: false
+    run: azd-hooks/prepackage.ps1
+  postpackage:
+    shell: pwsh
+    continueOnError: false
+    interactive: false
+    run: azd-hooks/postpackage.ps1


### PR DESCRIPTION

## Description

Adds deployment and provisioning hooks for Azd
Implements pre-deploy, post-deploy, pre-provision, and post-provision hooks for both POSIX and Windows environments.

Enhances deployment automation by allowing custom scripts to run during the deployment lifecycle.

## Related Issue(s)

Resolves #70
Closes #70