### PR TITLE
Set default values for push trigger

### DIFF
--- a/.github/workflows/Deploy-main.yaml
+++ b/.github/workflows/Deploy-main.yaml
@@ -19,7 +19,7 @@ on:
     # Run when commits are pushed to mainline branch
     # Set this to the mainline branch you are using
     branches:
-      - hadwa/set_wf_push_values
+      - main
 # GitHub Actions workflow to deploy to Azure using azd
 
 permissions:
@@ -67,8 +67,6 @@ jobs:
 
       - name: Provision Infrastructure
         env:
-          # AZURE_ENV_NAME: "${{ github.event.inputs.azd_environment_name || 'CICD' }}"
-          # AZURE_LOCATION: "${{ github.event.inputs.azure_location || 'eastus' }}"
           POWER_PLATFORM_USE_CLI: false
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           RS_ACCOUNT_NAME: ${{ secrets.RS_ACCOUNT_NAME }}
@@ -102,8 +100,6 @@ jobs:
       - name: Azd down
         if: ${{ github.event.inputs.run_azd_down == true }}
         env:
-          # AZURE_ENV_NAME: "${{ github.event.inputs.azd_environment_name || 'CICD' }}"
-          # AZURE_LOCATION: "${{ github.event.inputs.azure_location || 'eastus' }}"
           POWER_PLATFORM_USE_CLI: false
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           RS_ACCOUNT_NAME: ${{ secrets.RS_ACCOUNT_NAME }}


### PR DESCRIPTION
## Description

When workfkow is triggered automatically on push it fails due to missing default values for env_name and location. This PR sets fall back default values to fix it

## Related Issue(s)

 Resolves #91 
Closes #91
