### PR TITLE
Create exception for gitleaks sample secrets on readme.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,4 +452,5 @@ infra_lint_res.xml
 gitleaks-detect-*.json
 gitleaks
 gitleaks.tar.gz
+gitleaks_findings.json
 LICENSE

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -342,16 +342,22 @@ regex = '''xoxb-[a-z0-9]+-[a-z0-9]+'''
 path = '''\.(?:ps1|psm1|js|json|coffee|xml|js|md|html|py|php|java|ipynb|rb)$|hubot'''
 
 [allowlist]
-description = "Allowlisted files"
+description = "Allowlisted files and patterns"
 paths = [
   '''(.*?)(png|tif|tiff|pyc)$''',
   '''buildsearchers.xml''',
   '''UDMSecretChecks.toml''',
   '''UDMSecretChecksv8.toml''',
   '''GitleaksUdmCombo.toml''',
+  '''README\.md$'''
 ]
 regexTarget = "line"
-regexes = ['''#GitLeaksIgnore''']
+regexes = [
+  '''#GitLeaksIgnore''',
+  '''aws_secret= \"AKIAIMNOJVGFDXXXE4OA\"''',
+  '''AKIAIMNOJVGFDXXXE4OA''',
+  '''export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=cafebabe:deadbeef'''
+]
 
 commits = []
 repos = []

--- a/docs/gitleaks-config.md
+++ b/docs/gitleaks-config.md
@@ -1,0 +1,66 @@
+# GitLeaks Configuration Notes
+
+## Allowlisted Secrets
+
+This repository contains some example secrets in documentation files that are intentionally allowlisted in our `.gitleaks.toml` configuration. These are not real secrets but are included as part of code examples or documentation to illustrate proper configuration patterns.
+
+### Current allowlisted secrets:
+
+1. `aws_secret= "AKIAIMNOJVGFDXXXE4OA"` - This is a sample AWS key used in examples
+2. `export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=cafebabe:deadbeef` - This is a sample key used in examples
+
+## How Our Allowlist Works
+
+In our `.gitleaks.toml` file, we've configured the allowlist like this:
+
+```toml
+[allowlist]
+description = "Allowlisted files and patterns"
+paths = [
+  # Other paths...
+  '''README\.md$'''  # Allow in README.md file
+]
+regexes = [
+  # Other patterns...
+  '''aws_secret= \"AKIAIMNOJVGFDXXXE4OA\"''',
+  '''AKIAIMNOJVGFDXXXE4OA''',
+  '''export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=cafebabe:deadbeef'''
+]
+```
+
+This configuration tells GitLeaks to ignore these specific patterns in our README.md file.
+
+## Why We Use Allowlisting
+
+We use allowlisting instead of removing these example secrets because:
+
+1. They are explicitly fake/sample secrets used for documentation purposes
+2. They help illustrate proper configurations or setup instructions
+3. Removing them might make the documentation less clear for users
+
+## Important Security Notes
+
+- **Never** commit real credentials to this repository
+- Always use environment variables, Key Vault, or other secure methods to manage real secrets
+- If you need to include a sample secret in documentation, use obvious fake values (e.g., "EXAMPLE-KEY-12345")
+- When possible, add the `#GitLeaksIgnore` comment to lines containing example secrets
+
+## Running Secret Scans
+
+To scan for real secrets that might have been accidentally committed, run:
+
+### PowerShell:
+
+```powershell
+# From repository root
+.\azd-hooks\scripts\hooks\preprovision\run_gitleaks.ps1
+```
+
+## What To Do If Real Secrets Are Found
+
+If real secrets are detected:
+
+1. **Immediately revoke and rotate the credentials**
+2. Use tools like BFG Repo-Cleaner to remove the secrets from Git history
+3. Add proper allowlist entries only for example/documentation secrets
+4. Review your Git workflow to prevent future leaks


### PR DESCRIPTION
This pull request updates the `.gitleaks.toml` configuration and adds documentation to clarify the use of allowlisted secrets. The changes aim to enhance the clarity and security of the repository by explicitly defining allowlisted patterns and providing detailed guidance on secret management.

### Updates to `.gitleaks.toml` configuration:

* Expanded the description of the allowlist to include "patterns" in addition to files.
* Added `README.md` to the list of allowlisted file paths.
* Introduced new allowlisted regex patterns for example secrets, including a sample AWS key and a sample enterprise bundle key.

### Documentation improvements:

* Created a new file `docs/gitleaks-config.md` to explain the purpose and usage of the allowlist in `.gitleaks.toml`. This includes:
  - A list of current allowlisted secrets and their purposes.
  - Instructions on how the allowlist is configured and why it is used.
  - Security best practices for managing real secrets and using example secrets in documentation.
  - Steps for running secret scans and handling detected real secrets.… and add gitleaks configuration documentation



## Related Issue(s)

Resolves". #106 

