### PR TITLE
Fix resource_share_user string in main.tfvars.json

### DIFF
--- a/infra/main.tfvars.json
+++ b/infra/main.tfvars.json
@@ -1,5 +1,5 @@
 {
     "location": "${AZURE_LOCATION}",
     "azd_environment_name": "${AZURE_ENV_NAME}",
-    "resource_share_user": ${RESOURCE_SHARE_USER}
+    "resource_share_user": "${RESOURCE_SHARE_USER}"
 }


### PR DESCRIPTION
## Description

This pull request includes a small change to the `infra/main.tfvars.json` file. The change ensures that the `resource_share_user` value is properly enclosed in quotes to maintain consistency and prevent errors during parsing.

## Related Issue(s)

Resolves #127 

