### PR TITLE
Ianjensenisme/111 secure archives

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install GitLeaks
         run: |
-          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.17.0/gitleaks_8.17.0_linux_x64.tar.gz -o gitleaks.tar.gz
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz -o gitleaks.tar.gz
           tar -xzf gitleaks.tar.gz
           chmod +x gitleaks
           sudo mv gitleaks /usr/local/bin/

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Install GitLeaks
         run: |
-          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.17.0/gitleaks_8.17.0_linux_x64.tar.gz -o gitleaks.tar.gz
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz -o gitleaks.tar.gz
           tar -xzf gitleaks.tar.gz
           chmod +x gitleaks
           sudo mv gitleaks /usr/local/bin/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,11 @@ repos:
       - id: terraform_validate
         args: [infra]
 
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.2
+  - repo: local
     hooks:
       - id: gitleaks
-        args: ['git, --max-archive-depth=50', '--verbose']
+        name: Detect hardcoded secrets in staged files
+        entry: gitleaks
+        args: ['detect', '--verbose', '--max-archive-depth=50', '--no-git']
+        language: system
+        pass_filenames: true


### PR DESCRIPTION
## Description
This pull request updates how GitLeaks is installed and run in both CI workflows and local pre-commit checks. The main changes involve upgrading the GitLeaks version, switching from the GitHub Action to a direct install and script-based invocation, and improving scan parameters for more thorough secret detection.

**CI/CD Workflow Updates:**

* Upgraded the GitLeaks version to `v8.28.0` and replaced the GitLeaks GitHub Action with a manual installation and invocation script in both `.github/workflows/azure-dev.yml` and `.github/workflows/terraform-validate.yml`. This allows for more control over scan options and ensures consistent behavior across workflows. [[1]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L58-R77) [[2]](diffhunk://#diff-df26f8b79092c91c3562d81f8cd86d22046332b627b622f6bd51138d34415ec7R122-R152)
* Enhanced the GitLeaks scan command by adding `--max-archive-depth 50` for deeper archive scanning, using SARIF report output, and ensuring the scan always completes (with `--exit-code 0 || true`). [[1]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L58-R77) [[2]](diffhunk://#diff-df26f8b79092c91c3562d81f8cd86d22046332b627b622f6bd51138d34415ec7R122-R152)
* Updated the SARIF report path in the upload step to match the new output file name (`gitleaks-report.sarif`).

**Pre-commit Hook Improvements:**

* Switched the pre-commit GitLeaks hook from using the remote repository to a local installation, and updated the hook configuration to use the new scan parameters (`--max-archive-depth=50`, `--no-git`, etc.) for improved detection of secrets in staged files.

## Related Issue(s)

Resolves #111 