### PR TITLE
Update Security Considerations Diagram

### DIFF
--- a/docs/security_considerations.md
+++ b/docs/security_considerations.md
@@ -95,21 +95,14 @@ flowchart TB
                     DS_Delegation[ACI Delegation]
                     DS_NSG -.-> DS_Delegation
                 end
-                subgraph GHR_Subnet[GitHub Runner Subnet<br/>*Optional*]
-                    GHR_NSG[GitHub Runner NSG<br/>*Optional*]
-                    GHR_Delegation[ACA Environment Delegatio]
-                    GHR_NSG -.-> GHR_Delegation
-                end
                 subgraph PE_Subnet[Private Endpoint<br/>Subnet]
                     PE_NSG[Private Endpoint NSG]
                     PE_AOAI[Private Endpoint<br/>Azure OpenAI]
                     PE_AIS[Private Endpoint<br/>AI Search]
                     PE_Storage[Private Endpoint<br/>Storage]
-                    PE_ACR[Private Endpoint<br/>Container Registry]
                     PE_NSG -.-> PE_AOAI
                     PE_NSG -.-> PE_AIS
                     PE_NSG -.-> PE_Storage
-                    PE_NSG -.-> PE_ACR
                 end
             end
             
@@ -119,15 +112,12 @@ flowchart TB
                 Storage[Main Storage Account]
                 DSStorage[Deployment Storage Account]
                 AppInsights[Application Insights<br/>*Optional*]
-                ACR[Container Registry<br/>*Optional*]
-                
-                Runner[ACA GitHub Runner<br/>*Optional*]
+
                 NAT[NAT Gateway]
                 NATIP[NAT Gateway Public IP]
                 DS[Deployment Scripts]
                 DSMI[Deployment Script Managed Identity]
                 AISMI[AI Search Managed Identity]
-                RunnerLog[GitHub Runner Log Analytics<br/>*Optional*]
             end
             NIP[Network Injection Policy]
         end
@@ -136,15 +126,13 @@ flowchart TB
 
 
     PP ~~~ AZS
-    PP_Subnet ~~~ PE_Subnet ~~~ GHR_Subnet ~~~ DS_Subnet
+    PP_Subnet ~~~ PE_Subnet ~~~ DS_Subnet
     NIP -.-> PVNET ~~~ Resources
     DNS ~~~ PVNET
     AIS --> AISMI
     AISMI --> Storage
     AISMI --> AOAI
     DS --> DSMI --> DSStorage
-    Runner --> ACR
-    Runner --> RunnerLog
     NAT --> NATIP
 
 ```


### PR DESCRIPTION
Removed the GH Runner resources from the core architecture diagram.  

This pull request updates the `docs/security_considerations.md` diagram to simplify the network and resource architecture by removing references to the GitHub Runner subnet and associated optional components, as well as the Container Registry private endpoint. These changes help to clarify the diagram, focusing on the core required infrastructure.

**Diagram simplifications:**

* Removed the `GHR_Subnet` (GitHub Runner Subnet), `GHR_NSG` (GitHub Runner NSG), `GHR_Delegation`, and all connections related to GitHub Runners from the diagram. [[1]](diffhunk://#diff-ef26f4729a984216e8f00591b1ff6ea9666ac2d2efa9e590d7e7f96b8ed7f308L98-L112) [[2]](diffhunk://#diff-ef26f4729a984216e8f00591b1ff6ea9666ac2d2efa9e590d7e7f96b8ed7f308L122-L130) [[3]](diffhunk://#diff-ef26f4729a984216e8f00591b1ff6ea9666ac2d2efa9e590d7e7f96b8ed7f308L139-L147)
* Removed the `PE_ACR` (Private Endpoint for Container Registry) and its connections from the Private Endpoint subnet.
* Removed `ACR` (Container Registry), `Runner` (ACA GitHub Runner), and `RunnerLog` (GitHub Runner Log Analytics) from the resources section. [[1]](diffhunk://#diff-ef26f4729a984216e8f00591b1ff6ea9666ac2d2efa9e590d7e7f96b8ed7f308L122-L130) [[2]](diffhunk://#diff-ef26f4729a984216e8f00591b1ff6ea9666ac2d2efa9e590d7e7f96b8ed7f308L139-L147)
* Updated the subnet connectivity to eliminate references to the removed GitHub Runner subnet.## Description

Please include a summary of the changes.

## Related Issue(s)

Link to the issue(s) this PR is related to. Prefix with "Fixes" or "Resolves". **Every PR must be associated with an Issue**

_Example: Resolves #1234_
