### PR TITLE
fix: ensure default values for main.tfvars.json

### DIFF
--- a/infra/main.tfvars.json
+++ b/infra/main.tfvars.json
@@ -3,8 +3,8 @@
     "location": "${AZURE_LOCATION}",
     "use_billing_policy": "${USE_BILLING_POLICY:-false}",
     "azd_environment_name": "${AZURE_ENV_NAME}",
-    "resource_share_user": ${RESOURCE_SHARE_USER:-[]},
-    "tags": ${RESOURCE_TAGS:-{}},
+    "resource_share_user": ${RESOURCE_SHARE_USER:-null},
+    "tags": ${RESOURCE_TAGS:-null},
     "azure_ai_search_service_principal": {
         "client_id": "${AZURE_AI_SEARCH_SERVICE_PRINCIPAL_CLIENT_ID}",
         "enterprise_application_object_id": "${AZURE_AI_SEARCH_ENTERPRISE_APPLICATION_OBJECT_ID}",


### PR DESCRIPTION

This pull request makes a minor update to the `infra/main.tfvars.json` configuration file, improving its robustness by setting default values for certain variables. This change helps prevent errors when environment variables are unset.

* Configuration resilience:
  * Updated `resource_share_user` and `tags` to default to `null` if their respective environment variables are not set, ensuring smoother deployments and fewer runtime errors.

## Related Issue(s)

Link to the issue(s) this PR is related to. Prefix with "Fixes" or "Resolves". **Every PR must be associated with an Issue**

Resolves #311 
