### PR TITLE
Add debug flag support to azd commands in deployment workflows

### DIFF
--- a/.github/workflows/azure-dev-down.yml
+++ b/.github/workflows/azure-dev-down.yml
@@ -71,7 +71,7 @@ jobs:
           RS_RESOURCE_GROUP: ${{ vars.RS_RESOURCE_GROUP }}
           RESOURCE_SHARE_USER: ${{ vars.RESOURCE_SHARE_USER }}
           RESOURCE_TAGS: ${{ vars.RESOURCE_TAGS }}
-          
+
         shell: bash
         run: |
           azd config set auth.useAzCliAuth "true"
@@ -83,8 +83,14 @@ jobs:
           azd env set RESOURCE_TAGS "$RESOURCE_TAGS"
 
           azd package # trigger prepackage hook to setup terraform provider
-          azd provision --preview  # https://github.com/Azure/azure-dev/issues/4317
-          azd down --no-prompt --force --purge
+
+          # Detect if debug logging is enabled and set DEBUG_FLAG accordingly
+          DEBUG_FLAG=""
+          if [ "$ACTIONS_STEP_DEBUG" = "true" ] || [ "$ACTIONS_RUNNER_DEBUG" = "true" ] || [ "$RUNNER_DEBUG" = "1" ]; then
+            DEBUG_FLAG="--debug"
+          fi
+          azd provision --preview $DEBUG_FLAG  # https://github.com/Azure/azure-dev/issues/4317
+          azd down --no-prompt --force --purge $DEBUG_FLAG
 
       - name: Purge Soft-Deleted Azure OpenAI Resources
         shell: bash
@@ -97,7 +103,7 @@ jobs:
           # Only attempt to purge if we have the required information
           if [[ -n "$OPENAI_RESOURCE_NAME" && -n "$AZURE_REGION" ]]; then
             echo "Attempting to purge soft-deleted Azure OpenAI resource: $OPENAI_RESOURCE_NAME in $AZURE_REGION"
-            
+
             # Purge the soft-deleted Cognitive Services account (continue on error if resource not found)
             az cognitiveservices account purge \
               --location "$AZURE_REGION" \
@@ -106,4 +112,3 @@ jobs:
           else
             echo "OpenAI resource information not found in environment outputs. Skipping purge."
           fi
-

--- a/.github/workflows/azure-dev-down.yml
+++ b/.github/workflows/azure-dev-down.yml
@@ -82,13 +82,13 @@ jobs:
           azd env set RESOURCE_SHARE_USER "$RESOURCE_SHARE_USER"
           azd env set RESOURCE_TAGS "$RESOURCE_TAGS"
 
-          azd package # trigger prepackage hook to setup terraform provider
-
           # Detect if debug logging is enabled and set DEBUG_FLAG accordingly
           DEBUG_FLAG=""
           if [ "$ACTIONS_STEP_DEBUG" = "true" ] || [ "$ACTIONS_RUNNER_DEBUG" = "true" ] || [ "$RUNNER_DEBUG" = "1" ]; then
             DEBUG_FLAG="--debug"
           fi
+
+          azd package $DEBUG_FLAG # trigger prepackage hook to setup terraform provider
           azd provision --preview $DEBUG_FLAG  # https://github.com/Azure/azure-dev/issues/4317
           azd down --no-prompt --force --purge $DEBUG_FLAG
 

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -190,7 +190,12 @@ jobs:
           azd env set GITHUB_RUNNER_IMAGE_TAG "$GITHUB_RUNNER_IMAGE_TAG"
           azd env set GITHUB_RUNNER_IMAGE_BRANCH "$GITHUB_RUNNER_IMAGE_BRANCH"
 
-          azd provision --no-prompt
+          # Detect if debug logging is enabled and set DEBUG_FLAG accordingly
+          DEBUG_FLAG=""
+          if [ "$ACTIONS_STEP_DEBUG" = "true" ] || [ "$ACTIONS_RUNNER_DEBUG" = "true" ] || [ "$RUNNER_DEBUG" = "1" ]; then
+            DEBUG_FLAG="--debug"
+          fi
+          azd provision --no-prompt $DEBUG_FLAG
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: success() || failure()
@@ -241,7 +246,13 @@ jobs:
           azd env set RESOURCE_TAGS "$RESOURCE_TAGS"
 
           azd env select "$AZURE_ENV_NAME"
-          azd down --no-prompt --force --purge
+
+          # Detect if debug logging is enabled and set DEBUG_FLAG accordingly
+          DEBUG_FLAG=""
+          if [ "$ACTIONS_STEP_DEBUG" = "true" ] || [ "$ACTIONS_RUNNER_DEBUG" = "true" ] || [ "$RUNNER_DEBUG" = "1" ]; then
+            DEBUG_FLAG="--debug"
+          fi
+          azd down --no-prompt --force --purge $DEBUG_FLAG
 
       - name: Purge Soft-Deleted Azure OpenAI Resources
         if: ${{ github.event.inputs.run_azd_down == 'true' || github.event_name == 'pull_request' }}


### PR DESCRIPTION
Description
This PR adds GitHub's native debug logging support to Azure Developer CLI (azd) commands in the deployment workflows, enabling verbose output for troubleshooting infrastructure provisioning and teardown operations.

Changes Made
azure-dev.yml (CI-Deploy workflow)

Added inline debug flag detection using DEBUG_FLAG variable pattern for azd provision command
Added inline debug flag detection using DEBUG_FLAG variable pattern for azd down command
Simplified implementation with no external dependencies
azure-dev-down.yml (CI Destroy Resources workflow)

Added inline debug flag detection using DEBUG_FLAG variable pattern for azd provision --preview command
Added inline debug flag detection using DEBUG_FLAG variable pattern for azd down command
Simplified implementation with no external dependencies
When debug logging is enabled, the --debug flag is passed to azd commands, providing:

Detailed infrastructure provisioning steps
Terraform/Bicep plan and apply output
Resource creation/deletion logs
Hook execution details
Error stack traces with full context
How to enable debug mode
To see verbose output from azd commands:

Click "Re-run jobs" on a workflow run
Check "Enable debug logging"
Click "Re-run jobs"
GitHub automatically sets the environment variables ACTIONS_STEP_DEBUG, ACTIONS_RUNNER_DEBUG, and RUNNER_DEBUG, which the workflow detects to add the --debug flag to azd commands.

Technical approach
DEBUG_FLAG variable pattern:

# Detect if debug logging is enabled and set DEBUG_FLAG accordingly
DEBUG_FLAG=""
if [ "$ACTIONS_STEP_DEBUG" = "true" ] || [ "$ACTIONS_RUNNER_DEBUG" = "true" ] || [ "$RUNNER_DEBUG" = "1" ]; then
  DEBUG_FLAG="--debug"
fi
azd provision --no-prompt $DEBUG_FLAG
azd down --no-prompt --force --purge $DEBUG_FLAG
This approach uses a simple variable to conditionally append the --debug flag, eliminating command duplication in if/else branches.

Benefits
✅ Simple implementation: Inline logic with no external scripts
✅ No duplication: Single azd command invocation with conditional DEBUG_FLAG
✅ Easy to understand: All logic visible directly in workflow files
✅ Consistent behavior: Same pattern across all azd command invocations
✅ Maintainable: Straightforward conditional logic

Modified Files
.github/workflows/azure-dev.yml - Added DEBUG_FLAG pattern for azd provision and azd down
.github/workflows/azure-dev-down.yml - Added DEBUG_FLAG pattern for azd provision and azd down
Related Issue(s)
Links to related issues will be added by the system

Original prompt
Fixes [Bug] Linter Workflow Outputs No Error Details #254