### PR TITLE
Reverting azapi to the last known stable version.

### DIFF
--- a/infra/modules/copilot_studio/terraform.tf
+++ b/infra/modules/copilot_studio/terraform.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "2.9.0"
+      version = "2.7.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "2.9.0"
+      version = "2.7.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "2.7.0"
+      version = "2.9.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
## Description

Reverting the azapi provider back to 2.7.0, the last known stable version.

## Related Issue(s)

Resolves #389 
